### PR TITLE
Utc timezone

### DIFF
--- a/stand/scheduler/scheduler.py
+++ b/stand/scheduler/scheduler.py
@@ -88,7 +88,7 @@ async def execute(config, current_time=datetime.now(timezone.utc)):
     for command in update_pipeline_runs_commands:
         if logger.isEnabledFor(logging.INFO):
             logger.info("Executing command %s.", command)
-        # await command.execute(config)
+        await command.execute(config)
 
     # must be called again bc pipeline_runs_commands can create new runs
 

--- a/stand/scheduler/scheduler.py
+++ b/stand/scheduler/scheduler.py
@@ -20,14 +20,14 @@ logger = logging.getLogger(__name__)
 
 async def check_and_execute(config):
     while True:
-        current_time = datetime.now()
+        current_time = datetime.datetime.utcnow()
         logger.info("Checking scheduler. Now = %s", current_time.isoformat())
         try:
             await execute(config, current_time=current_time)
         except Exception as e:
             logger.exception(e)
 
-        current_time = datetime.now()
+        current_time = datetime.datetime.utcnow()
         remaining_seconds = (
             60 - current_time.second - (current_time.microsecond / 1_000_000)
         )
@@ -37,7 +37,7 @@ async def check_and_execute(config):
 # FIXME: Theres redundancy in the api call to get the pipelines
 # first they are called in a batch then called individualy,bc the
 # batch api doesnt return the step runs
-async def execute(config, current_time=datetime.now()):
+async def execute(config, current_time=datetime.datetime.utcnow()):
     # returned as pipeline_id:pipeline_in_json dict
     period = 7
     updated_pipelines = await get_pipelines(

--- a/stand/scheduler/update_pipeline_runs.py
+++ b/stand/scheduler/update_pipeline_runs.py
@@ -1,6 +1,6 @@
 import typing
 from datetime import datetime
-
+import pytz
 from stand.models import (
     PipelineRun,
     StatusExecution,
@@ -28,7 +28,9 @@ def get_pipeline_run_commands(
 
         if run:
             # run expired
-            if run.finish < current_time:
+            finish_utc = run.finish.astimezone(pytz.utc) if run.finish.tzinfo else pytz.utc.localize(run.finish)
+            current_time_utc = current_time.astimezone(pytz.utc) if current_time.tzinfo else pytz.utc.localize(current_time)
+            if finish_utc < current_time_utc:
                 # all steps completed
                 if run.last_executed_step == len(run.steps):
                     commands.append(


### PR DESCRIPTION
Fix for timezone, everything going to the stand backend is in UTC and the function that compares times to trigger scheduled pipelinesteps takes an argument on the format "América/são-paulo". TODO: get this argument on a config file. 