### PR TITLE
Fix: handle mismatch between pipeline steps and step runs.

### DIFF
--- a/stand/pipeline_run_api.py
+++ b/stand/pipeline_run_api.py
@@ -117,8 +117,8 @@ class PipelineRunListApi(Resource):
                 PipelineRun.pipeline_id.in_(pipeline_ids)
             )
 
+    
         latest_filter = request.args.get("latest")
-
         if latest_filter in ("true", 1, "True", "1"):
             subquery = db.session.query(
                 PipelineRun.pipeline_id,

--- a/stand/scheduler/scheduler.py
+++ b/stand/scheduler/scheduler.py
@@ -6,6 +6,9 @@ from datetime import timezone
 from stand.scheduler.trigger_scheduled_jobs import (
     trigger_scheduled_pipeline_steps,
 )
+from stand.models import (
+    StatusExecution,
+)
 from stand.scheduler.update_pipeline_runs import get_pipeline_run_commands
 from stand.scheduler.utils import (
     get_latest_pipeline_runs,
@@ -54,8 +57,7 @@ async def execute(config, current_time=None):
         config, valid_schedule_pipelines
     )
     if logger.isEnabledFor(logging.INFO):
-    
-        logger.info("fetched %s active pipelines runs.", len(active_pipeline_runs))
+        logger.info("fetched %s active and scheduled pipelines runs.", len(active_pipeline_runs))
 
     # update pipeline runs for scheduled pipelines
     update_pipeline_runs_commands = get_pipeline_run_commands(
@@ -80,6 +82,8 @@ async def execute(config, current_time=None):
     active_pipeline_runs = await fetch_active_pipeline_runs(
         config, unvalid_schedule_pipelines,latest_only=False
     )
+    if logger.isEnabledFor(logging.INFO):
+        logger.info("fetched %s active and API created pipelines runs.", len(active_pipeline_runs))
 
     # triggering pipeline steps for non scheduled pipelines (pipeline runs created by api)
     trigger_commands = prepare_trigger_commands(
@@ -136,15 +140,16 @@ def prepare_trigger_commands(
     for run in active_pipeline_runs:
         step_infos = valid_schedule_pipelines[run.pipeline_id]["steps"]
         step_runs = [step for step in run.steps]
-        
+        if  run.status in(StatusExecution.COMPLETED, StatusExecution.CANCELED,StatusExecution.ERROR):
+            continue
         if(len(step_infos)!=len(step_runs)):
             if logger.isEnabledFor(logging.INFO):
                 log_message = (
                     f"Pipeline run {run.id} and its base Pipeline {run.pipeline_id} don't have the same number of steps.The pipeline's steps were changed after the run was created. This run will be ignored until a user manually complete it or cancel it"
                 )
                 logger.info(log_message)
-            return []
-        
+            continue
+      
         new_command = trigger_scheduled_pipeline_steps(
             pipeline_run=run,
             time=current_time,

--- a/stand/scheduler/scheduler.py
+++ b/stand/scheduler/scheduler.py
@@ -78,7 +78,7 @@ async def execute(config, current_time=None):
 
     # fetching pipeline runs created by the API
     active_pipeline_runs = await fetch_active_pipeline_runs(
-        config, unvalid_schedule_pipelines
+        config, unvalid_schedule_pipelines,latest_only=False
     )
 
     # triggering pipeline steps for non scheduled pipelines (pipeline runs created by api)
@@ -118,11 +118,13 @@ def filter_non_valid_schedule_pipelines(updated_pipelines):
     }
 
 
-async def fetch_active_pipeline_runs(config, valid_schedule_pipelines):
+async def fetch_active_pipeline_runs(config, valid_schedule_pipelines,latest_only=True):
     """Fetches the latest pipeline runs for valid pipelines."""
     return await get_latest_pipeline_runs(
+       
         config["stand"]["services"]["stand"],
         pipeline_ids=valid_schedule_pipelines.keys(),
+        latest_only=latest_only
     )
 
 
@@ -134,6 +136,15 @@ def prepare_trigger_commands(
     for run in active_pipeline_runs:
         step_infos = valid_schedule_pipelines[run.pipeline_id]["steps"]
         step_runs = [step for step in run.steps]
+        
+        if(len(step_infos)!=len(step_runs)):
+            if logger.isEnabledFor(logging.INFO):
+                log_message = (
+                    f"Pipeline run {run.id} and its base Pipeline {run.pipeline_id} don't have the same number of steps.The pipeline's steps were changed after the run was created. This run will be ignored until a user manually complete it or cancel it"
+                )
+                logger.info(log_message)
+            return []
+        
         new_command = trigger_scheduled_pipeline_steps(
             pipeline_run=run,
             time=current_time,

--- a/stand/scheduler/trigger_scheduled_jobs.py
+++ b/stand/scheduler/trigger_scheduled_jobs.py
@@ -182,6 +182,6 @@ def trigger_scheduled_pipeline_steps(
         for index, step in enumerate(steps):
             if is_next_step_in_order(
                 step, pipeline_run
-            ) and no_job_already_active_for_step_run(step, pipeline_run):
+            ) and no_job_already_active_for_step_run(step, pipeline_run) and pipeline_run.status not in (StatusExecution.ERROR,StatusExecution.CANCELED):
                 command = TriggerWorkflow(pipeline_step=step_runs[index])
                 return command

--- a/stand/scheduler/trigger_scheduled_jobs.py
+++ b/stand/scheduler/trigger_scheduled_jobs.py
@@ -147,6 +147,7 @@ def trigger_scheduled_pipeline_steps(
     scheduled: bool
 ):
 
+ 
     # run created by the scheduler
     if scheduled:
         for index, step in enumerate(steps):
@@ -176,7 +177,7 @@ def trigger_scheduled_pipeline_steps(
                     return command
 
     # run created by the coletor, only needs to check order and if theres any step
-    # of this run already running
+    # of this run already running. 
     else:
         for index, step in enumerate(steps):
             if is_next_step_in_order(

--- a/stand/scheduler/utils.py
+++ b/stand/scheduler/utils.py
@@ -10,6 +10,7 @@ import yaml
 from stand.models import (
     PipelineRun,
     PipelineStepRun,
+    StatusExecution,
 )
 from stand.schema import PipelineRunItemResponseSchema
 
@@ -19,23 +20,53 @@ async def get_latest_pipeline_step_run(run: PipelineRun) -> PipelineStepRun:
 
 
 async def get_latest_pipeline_runs(
-    stand_config: typing.Dict, pipeline_ids: typing.List[int]
+    stand_config: typing.Dict, pipeline_ids: typing.List[int],latest_only= True
 ) -> typing.List[PipelineRun]:
-    """"""
-
     if len(pipeline_ids) == 0:
         return []
+
     headers = {"X-Auth-Token": str(stand_config["auth_token"])}
     url = f"{stand_config['url']}/pipeline-runs"
 
-    params = {
+    page = 1
+    page_size = 20
+    all_runs = []
+    if not latest_only:
+        while True:
+            params = {
+                "pipelines": ",".join([str(x) for x in pipeline_ids]),
+                "page": page,
+                "size": page_size,
+            }
+
+            data = await retrieve_data(url, params=params, headers=headers)
+
+        
+            page_data = data.get("data", [])
+            if not page_data:
+                break
+
+        
+            runs = PipelineRunItemResponseSchema(many=True, partial=True).load(page_data)
+            all_runs.extend(runs)
+
+            pagination = data.get("pagination", {})
+            total_pages = pagination.get("pages", 1)
+
+            if page >= total_pages:
+                break
+            page += 1
+
+        return all_runs
+    else:
+        params = {
         "latest": "true",
         "pipelines": ",".join([str(x) for x in pipeline_ids]),
-    }
+        }
 
-    data = await retrieve_data(url, params=params, headers=headers)
+        data = await retrieve_data(url, params=params, headers=headers)
 
-    return PipelineRunItemResponseSchema(many=True, partial=True).load(data)
+        return PipelineRunItemResponseSchema(many=True, partial=True).load(data)
 
 
 async def get_pipelines(
@@ -129,18 +160,16 @@ def pipeline_steps_have_valid_schedulings(steps: typing.List):
     for step in steps:
         if "scheduling" in step and "workflow" in step:
             schedule = json.loads(step["scheduling"])
-            
             schedule = schedule["stepSchedule"]
           
             if (
                 schedule["executeImmediately"] == "true"
                 or (schedule["startDateTime"] != "null"
                
-                and schedule["months"]!=[])
-              
-                
+                and schedule["months"]!=[]) 
             ):
                 pass
+            
             else:
                 return False
         else:

--- a/stand/scheduler/utils.py
+++ b/stand/scheduler/utils.py
@@ -56,7 +56,7 @@ async def get_latest_pipeline_runs(
             if page >= total_pages:
                 break
             page += 1
-
+        
         return all_runs
     else:
         params = {

--- a/stand/services/pipeline_run_service.py
+++ b/stand/services/pipeline_run_service.py
@@ -161,11 +161,19 @@ def update_pipeline_run(job: Job) -> None:
     """ Update associated pipeline step run, if any """
 
     job.pipeline_step_run.status = job.status
-    if job.status in (EXEC.ERROR, EXEC.CANCELED, EXEC.INTERRUPTED):
+    
+    #if the run was  completed once, only change the status of the run 
+    # to error if an error occur otherwise ignore
+    if job.pipeline_run.status in (EXEC.COMPLETED,EXEC.CANCELED, ):
+        if job.status in (EXEC.ERROR,):
+            job.pipeline_run.status = job.status
+            
+    elif job.status in (EXEC.ERROR, EXEC.CANCELED, EXEC.INTERRUPTED):
         job.pipeline_run.status = job.status
         job.pipeline_run.final_status = job.status
-    elif job.status in (EXEC.COMPLETED, ):
+        
 
+    elif job.status in (EXEC.COMPLETED, ):
         # Test if the step is the last one
         step_order = job.pipeline_step_run.order
         job.pipeline_run.last_executed_step = step_order
@@ -179,7 +187,7 @@ def update_pipeline_run(job: Job) -> None:
                         EXEC.WAITING_INTERVENTION):
         pass # Ignore
     elif job.status in (EXEC.RUNNING, ):
-        pass # FIXME
+        pass # Ignore
 
     db.session.add(job.pipeline_step_run)
     db.session.add(job.pipeline_run)

--- a/stand/services/pipeline_run_service.py
+++ b/stand/services/pipeline_run_service.py
@@ -161,28 +161,46 @@ def update_pipeline_run(job: Job) -> None:
     """ Update associated pipeline step run, if any """
 
     job.pipeline_step_run.status = job.status
-    if job.status in (EXEC.ERROR, EXEC.CANCELED, EXEC.INTERRUPTED):
-        job.pipeline_run.status = job.status
-        job.pipeline_run.final_status = job.status
-    elif job.status in (EXEC.COMPLETED, ):
 
-        # Test if the step is the last one
-        step_order = job.pipeline_step_run.order
+    step_order = job.pipeline_step_run.order
+    if job.status == EXEC.COMPLETED and job.pipeline_run.last_executed_step < step_order:
         job.pipeline_run.last_executed_step = step_order
-        if step_order == len(job.pipeline_run.steps):
-            job.pipeline_run.status = EXEC.COMPLETED
-        else:
-            #job completed should make pipeline run go to waiting
-            job.pipeline_run.status = EXEC.WAITING
 
-    elif job.status in (EXEC.PENDING, EXEC.WAITING,
-                        EXEC.WAITING_INTERVENTION):
-        pass # Ignore
-    elif job.status in (EXEC.RUNNING, ):
-        pass # FIXME
+    last_step = job.pipeline_run.last_executed_step
+
+ 
+    step_statuses = {
+        step.order: (job.status if step.id == job.pipeline_step_run.id else step.status)
+        for step in job.pipeline_run.steps
+    }
+
+    all_statuses = list(step_statuses.values())
+
+    all_prior_completed = all(
+        step_statuses[o] == EXEC.COMPLETED
+        for o in step_statuses
+        if o < last_step
+    )
+    all_after_pending = all(
+        step_statuses[o] == EXEC.PENDING
+        for o in step_statuses
+        if o >= last_step
+    )
+
+    if EXEC.RUNNING in all_statuses:
+        job.pipeline_run.status = EXEC.RUNNING
+    elif EXEC.ERROR in all_statuses:
+        job.pipeline_run.status = EXEC.ERROR
+    elif all_prior_completed and all_after_pending:
+        job.pipeline_run.status = EXEC.WAITING
+    elif all(status == EXEC.COMPLETED for status in all_statuses):
+        job.pipeline_run.status = EXEC.COMPLETED
+    else:
+        job.pipeline_run.status = EXEC.PENDING
 
     db.session.add(job.pipeline_step_run)
     db.session.add(job.pipeline_run)
+
     
 def change_pipeline_run_status(run: PipelineRun, status: StatusExecution,
                                emit: callable) -> None:

--- a/stand/services/pipeline_run_service.py
+++ b/stand/services/pipeline_run_service.py
@@ -161,19 +161,11 @@ def update_pipeline_run(job: Job) -> None:
     """ Update associated pipeline step run, if any """
 
     job.pipeline_step_run.status = job.status
-    
-    #if the run was  completed once, only change the status of the run 
-    # to error if an error occur otherwise ignore
-    if job.pipeline_run.status in (EXEC.COMPLETED,EXEC.CANCELED, ):
-        if job.status in (EXEC.ERROR,):
-            job.pipeline_run.status = job.status
-            
-    elif job.status in (EXEC.ERROR, EXEC.CANCELED, EXEC.INTERRUPTED):
+    if job.status in (EXEC.ERROR, EXEC.CANCELED, EXEC.INTERRUPTED):
         job.pipeline_run.status = job.status
         job.pipeline_run.final_status = job.status
-        
-
     elif job.status in (EXEC.COMPLETED, ):
+
         # Test if the step is the last one
         step_order = job.pipeline_step_run.order
         job.pipeline_run.last_executed_step = step_order
@@ -187,11 +179,11 @@ def update_pipeline_run(job: Job) -> None:
                         EXEC.WAITING_INTERVENTION):
         pass # Ignore
     elif job.status in (EXEC.RUNNING, ):
-        pass # Ignore
+        pass # FIXME
 
     db.session.add(job.pipeline_step_run)
     db.session.add(job.pipeline_run)
-
+    
 def change_pipeline_run_status(run: PipelineRun, status: StatusExecution,
                                emit: callable) -> None:
     run.status = status


### PR DESCRIPTION
FIX: The bug described in [issue #460](https://github.com/eubr-bigsea/citrus/issues/460) was caused by a mismatch between the number of steps in a pipeline run and its corresponding pipeline. Basically, if you created a pipeline run and then added or removed a step from the pipeline, the error would occur.

UPDATE: Now the get_latest_pipeline_runs util function can be parametrized to either get only the latests or all of the runs from a given pipeline. 