### PR TITLE
FIX: small api fix for empty context in pipeline_run/create endpoint

### DIFF
--- a/stand/services/pipeline_run_service.py
+++ b/stand/services/pipeline_run_service.py
@@ -75,7 +75,7 @@ def create_pipeline_run_from_pipeline(
     start = period.start.astimezone(pytz.UTC)
     finish = period.finish.astimezone(pytz.UTC)
     if context is None or len(context) == 0:
-        context_data=None
+        context_data=[]
     else:
         context_data = [
             PipelineRunContextData(name=ctx.get('name'), value=ctx.get('value'))


### PR DESCRIPTION
the field context_data cannot be None in PipelineRunContextData", so in the API if no context_data is received, then a empty list is used instead of None.